### PR TITLE
Adding CircleCI; fixing AWS version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: "ruby:1.9.3-slim"
+    steps:
+      - checkout
+      - run:
+          name: Build gem
+          command: |
+            gem build firewall_generator.gemspec
+            mv firewall_generator*.gem firewall_generator.gem
+      - run:
+          name: Push gem to GemFury (if master)
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              curl --fail -F package=@firewall_generator.gem https://${GEMFURY_TOKEN}@push.fury.io/moovweb/
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: "ruby:1.9.3-slim"
+      - image: ruby:1.9.3
     steps:
       - checkout
       - run:

--- a/firewall_generator.gemspec
+++ b/firewall_generator.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.add_runtime_dependency 'aws-sdk'
+  gem.add_runtime_dependency 'aws-sdk', '< 2'
 end

--- a/lib/firewall_generator/version.rb
+++ b/lib/firewall_generator/version.rb
@@ -1,3 +1,3 @@
 module FirewallGenerator
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
This will stop the following errors in production:

```
/usr/local/rvm/gems/ruby-1.9.3-p429@prod/gems/firewall_generator-0.0.1/lib/firewall_generator/input/aws.rb:27:in `block in all_public_ips': uninitialized constant FirewallGenerator::Input::Aws::AWS (NameError)
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/gems/firewall_generator-0.0.1/lib/firewall_generator/input/aws.rb:26:in `tap'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/gems/firewall_generator-0.0.1/lib/firewall_generator/input/aws.rb:26:in `all_public_ips'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/gems/firewall_generator-0.0.1/lib/firewall_generator/input/aws.rb:17:in `result'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/gems/firewall_generator-0.0.1/lib/firewall_generator/command.rb:32:in `block in run'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/gems/firewall_generator-0.0.1/lib/firewall_generator/command.rb:31:in `each'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/gems/firewall_generator-0.0.1/lib/firewall_generator/command.rb:31:in `run'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/gems/firewall_generator-0.0.1/bin/firewall_generator:5:in `<top (required)>'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/bin/firewall_generator:19:in `load'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/bin/firewall_generator:19:in `<main>'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/bin/ruby_executable_hooks:15:in `eval'
        from /usr/local/rvm/gems/ruby-1.9.3-p429@prod/bin/ruby_executable_hooks:15:in `<main>'
```